### PR TITLE
provide CMake as alternative build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 2.8)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_USER_MAKE_RULES_OVERRIDE "cmake/platform.cmake")
+
+project(VMD-h5mdplugin C)
+
+find_package(HDF5 REQUIRED)
+# find_package(VMD REQUIRED)
+# FIXME e.g., https://github.com/gromacs/gromacs/blob/master/cmake/FindVMD.cmake
+set(GMX_VMD_PLUGIN_PATH "$ENV{VMDDIR}/plugins/include" CACHE STRING "Path to VMD plugin headers")
+message(STATUS "VMD plugin path: ${GMX_VMD_PLUGIN_PATH}")
+
+include_directories("${HDF5_INCLUDE_DIR}")
+include_directories("${GMX_VMD_PLUGIN_PATH}")
+
+#
+# add H5MD library
+#
+add_library(h5md # SHARED
+    libh5md.c
+)
+
+#
+# add H5MD plugin
+#
+add_library(h5mdplugin SHARED
+    h5mdplugin.c
+)
+target_link_libraries(h5md
+    ${HDF5_LIBRARY}
+    ${HDF5_HL_LIBRARY}
+    # math library
+    m
+)
+
+# unset "lib" prefix
+set_target_properties(h5mdplugin PROPERTIES PREFIX "")
+
+target_link_libraries(h5mdplugin
+    h5md
+    ${HDF5_LIBRARY}
+    ${HDF5_HL_LIBRARY}
+)
+
+install(TARGETS h5mdplugin
+  DESTINATION "$ENV{VMDDIR}/plugins/LINUXAMD64/molfile"
+)
+
+#
+# add test
+#
+enable_testing()
+
+add_executable(h5mdtest
+    h5mdtest.c
+    h5mdplugin.c
+)
+target_link_libraries(h5mdtest
+    h5md
+    ${HDF5_LIBRARY}
+    ${HDF5_HL_LIBRARY}
+    # math library
+    m
+)
+
+add_test(h5md/particles/full_vmd_structure
+    h5mdtest h5md "${CMAKE_SOURCE_DIR}/samples/full_vmd_structure.h5"
+)
+add_test(h5md/particles/half_vmd_structure
+    h5mdtest h5md "${CMAKE_SOURCE_DIR}/samples/half_vmd_structure.h5"
+)
+add_test(h5md/particles/no_vmd_structure
+    h5mdtest h5md "${CMAKE_SOURCE_DIR}/samples/no_vmd_structure.h5"
+)

--- a/README
+++ b/README
@@ -1,7 +1,13 @@
-To compile the plugin, adapt the Makefile and run "make". This should work on any Unix that has VMD and HDF5 installed. For example under Ubuntu you need the package libhdf5-dev and the VMD sources.
+To compile the plugin, adapt the Makefile and run "make". This should work on
+any Unix that has VMD and HDF5 installed. For example under Ubuntu you need the
+package libhdf5-dev and the VMD sources.
 
-To load the plugin in VMD add the following line to your ~/.vmdrc (replace the directory to where you have compiled it):
+Alternatively, you may build the plugin with CMake, which requires the
+environment variable VMDDIR to be set.
+
+To load the plugin in VMD add the following line to your ~/.vmdrc (replace the
+directory to where you have compiled it):
 
         vmd_plugin_scandirectory /PATH_TO_SO_DIRECTORY/ h5mdplugin.so
-        
+
 Remarks: the plugin only works with threedimensional position datasets.

--- a/cmake/COPYING-CMAKE-SCRIPTS
+++ b/cmake/COPYING-CMAKE-SCRIPTS
@@ -1,0 +1,22 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products 
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -1,0 +1,82 @@
+# - Find HDF5
+# Find the Hierarchical Data Format 5 (HDF5) includes and library
+#
+# This module defines
+#  HDF5_FOUND
+#  HDF5_INCLUDE_DIR
+#  HDF5_LIBRARY
+#  HDF5_CPP_LIBRARY
+#  HDF5_HL_LIBRARY
+#  HDF5_LIBRARIES
+#
+
+#=============================================================================
+# Copyright 2002-2009 Kitware, Inc.
+# Copyright 2008-2011 Peter Colberg
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file COPYING-CMAKE-SCRIPTS for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(HDF5_INCLUDE_DIR hdf5.h
+  HINTS
+  $ENV{HDF5_DIR}
+  PATH_SUFFIXES include
+)
+
+if(HDF5_USE_STATIC_LIBS)
+  set( _HDF5_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  endif()
+endif()
+
+find_library(HDF5_LIBRARY NAMES hdf5
+  HINTS
+  $ENV{HDF5_DIR}
+  PATH_SUFFIXES lib64 lib
+)
+
+find_library(HDF5_CPP_LIBRARY NAMES hdf5_cpp
+  HINTS
+  $ENV{HDF5_DIR}
+  PATH_SUFFIXES lib64 lib
+)
+
+find_library(HDF5_HL_LIBRARY NAMES hdf5_hl
+  HINTS
+  $ENV{HDF5_DIR}
+  PATH_SUFFIXES lib64 lib
+)
+
+if(HDF5_USE_STATIC_LIBS)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_HDF5_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
+
+if(HDF5_LIBRARY AND HDF5_CPP_LIBRARY AND HDF5_HL_LIBRARY)
+  set(HDF5_LIBRARIES ${HDF5_LIBRARY} ${HDF5_CPP_LIBRARY} ${HDF5_HL_LIBRARY})
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(HDF5 DEFAULT_MSG
+  HDF5_INCLUDE_DIR
+  HDF5_LIBRARY
+  HDF5_CPP_LIBRARY
+  HDF5_HL_LIBRARY
+)
+
+mark_as_advanced(
+  HDF5_INCLUDE_DIR
+  HDF5_LIBRARY
+  HDF5_CPP_LIBRARY
+  HDF5_HL_LIBRARY
+)

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -1,0 +1,24 @@
+set(CMAKE_BUILD_TYPE_INIT "Release")
+
+if(DEFINED CMAKE_C_COMPILER_ID)
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU|Intel|Clang")
+    set(CMAKE_C_FLAGS_INIT "-Wall -std=c99 -pedantic -fPIC")
+  endif()
+endif()
+
+if(CMAKE_C_PLATFORM_ID STREQUAL "Linux")
+  set(CMAKE_SHARED_LINKER_FLAGS_INIT "-Wl,--no-undefined -Wl,--as-needed")
+  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_INIT "-Wl,-s")
+
+  # set appropriate RPATH on installed binaries as well as in build tree,
+  # see http://www.vtk.org/Wiki/CMake_RPATH_handling
+  #
+  # use, i.e. don't skip, the full RPATH for the build tree
+  set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+  # when building, don't use the install RPATH already
+  # (but later on when installing)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+  # add the automatically determined parts of the RPATH
+  # which point to directories outside the build tree to the install RPATH
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()


### PR DESCRIPTION
CMake makes the build and installation process really easy. Merely the environment variable VMDDIR needs to be set to find the VMD headers. To automate even this step, we could use https://github.com/gromacs/gromacs/blob/master/cmake/FindVMD.cmake.