### PR TITLE
CMake: fix linking against HDF5 HL library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(h5mdplugin SHARED
     h5mdplugin.c
 )
 target_link_libraries(h5md
-    ${HDF5_LIBRARIES}
+    ${HDF5_C_LIBRARIES}
+    ${HDF5_HL_LIBRARIES}
     # math library
     m
 )
@@ -50,7 +51,8 @@ set_target_properties(h5mdplugin PROPERTIES PREFIX "")
 
 target_link_libraries(h5mdplugin
     h5md
-    ${HDF5_LIBRARIES}
+    ${HDF5_C_LIBRARIES}
+    ${HDF5_HL_LIBRARIES}
 )
 
 install(TARGETS h5md h5mdplugin


### PR DESCRIPTION
Explicitly link against the high-level API of the HDF5 library. There may be
better solutions. Tested with CMake 3.2.0, 3.7.2, and 3.11.1.

Building with CMake ≥ 3.7 and HDF5 ≥ 1.8.16 failed:

libh5md.a(libh5md.c.o): In function `h5md_set_author':
libh5md.c:(.text+0xcd2): undefined reference to `H5LTset_attribute_string'
libh5md.c:(.text+0xcf1): undefined reference to `H5LTset_attribute_string'
libh5md.c:(.text+0xd40): undefined reference to `H5LTset_attribute_string'
libh5md.a(libh5md.c.o): In function `h5md_set_creator':
libh5md.c:(.text+0xdb9): undefined reference to `H5LTset_attribute_string'
libh5md.c:(.text+0xdd8): undefined reference to `H5LTset_attribute_string'
libh5md.a(libh5md.c.o):libh5md.c:(.text+0xe18): more undefined references to `H5LTset_attribute_string' follow
collect2: error: ld returned 1 exit status