### PR TITLE
compile h5mdtest.c with -fPIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: h5mdtest libh5md.so h5mdplugin.so
 
 #nasty
 h5mdtest: h5mdtest.c h5mdplugin.so libh5md.so
-	$(CC) h5mdtest.c -o h5mdtest h5mdplugin.c $(CPPFLAGS) -std=c99 $(LDFLAGS) -Wl,-rpath,'\$$ORIGIN' $(HDF5LIBS) -lh5md
+	$(CC) h5mdtest.c -o h5mdtest h5mdplugin.c $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -Wl,-rpath,'\$$ORIGIN' $(HDF5LIBS) -lh5md
 
 
 libh5md.so: libh5md.o


### PR DESCRIPTION
Needed on Ubuntu 18.04. Otherwise we get errors like
```
/usr/bin/ld: h5mdtest.o: relocation R_X86_64_32 against `.text' can not be used when making a PIE object; recompile with -fPIC
/usr/bin/ld: h5mdplugin.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
```
with clang or
```
/usr/bin/ld: h5mdplugin.o: relocation R_X86_64_PC32 against symbol `H5T_NATIVE_FLOAT_g@@HDF5_SERIAL_1.8.7' can not be used when making a shared object; recompile with -fPIC
```
with gcc.